### PR TITLE
Fix temp-dir! warning and pom key looking with latest boot version

### DIFF
--- a/src/clj/it/frbracch/boot_marginalia.clj
+++ b/src/clj/it/frbracch/boot_marginalia.clj
@@ -21,7 +21,7 @@
    m multi       bool    "Generate each namespace documentation as a separate file"]
   (fn [next]
     (fn [fileset]
-      (let [tgt       (core/temp-dir!)
+      (let [tgt       (core/tmp-dir!)
             dir       (or dir "docs")
             file      (or file "uberdoc.html")
             name      (or name (pom-option :project))

--- a/src/clj/it/frbracch/boot_marginalia.clj
+++ b/src/clj/it/frbracch/boot_marginalia.clj
@@ -7,7 +7,7 @@
             [marginalia.html :refer [*resources*]]))
 
 (defn pom-option [k]
-  (-> builtin/pom var meta k))
+  (-> builtin/pom var meta :task-options k))
 
 (deftask marginalia
   "Run Marginalia against your project source files"


### PR DESCRIPTION
The current version has a couple of issues:
1. A warning is emitted about the use of the deprecated function "temp-dir!" on each invocation.
2. Defaulting of the project name, version and description to those found in the pom options fails due to the path having changed in boot.

These commit fix both issues.
