### PR TITLE
Switched to forked version of marginalia...

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,6 @@
 (def +project+ 'it.frbracch/boot-marginalia)
 
-(def +version+ "0.1.3")
+(def +version+ "0.1.3-1")
 
 (def +description+ "boot plugin for marginalia")
 
@@ -8,7 +8,7 @@
 
 (def +dependencies+ '[[boot/core           "2.1.2" :scope "provided"]
                       [org.clojure/clojure "1.6.0" :scope "provided"]
-                      [marginalia          "0.8.0"]])
+                      [michaelblume/lein-marginalia "0.9.0"]])
 
 (def +url+ "https://github.com/francesco-bracchi/boot-marginalia")
 


### PR DESCRIPTION
Hi,

The current version of marginalia on github has become inactive and has compatibility issues with clojure 1.7+ (see issue here: https://github.com/gdeer81/marginalia/issues/153 ). A fix has been developed on a forked version of marginalia which resolves these issues. Unless the maintainer of marginalia becomes active I would suggest switching this boot plugin to use the forked version by MichaelBlume (https://github.com/MichaelBlume/marginalia).
